### PR TITLE
DFB-373: Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
I set `insert_final_newline = false`, since Henry mentioned that preference yesterday.

Many editors have built-in `editorconfig` support (including GitHub.com's editor!) Some editors (like Atom, Emacs, and Notepad++) require you [download a plugin.](https://editorconfig.org/#download)

I think our official decision yesterday was to open a PR and "play around with it," so I'll wait until both of you approve before merging.