### PR TITLE
Use email field in the form as default email for form draft email

### DIFF
--- a/app/Helpers/ControllerHelper.php
+++ b/app/Helpers/ControllerHelper.php
@@ -316,7 +316,6 @@ class ControllerHelper
           unset($updates['remove']);
           unset($updates['add']);
         }
-        Log::info(print_r($updates,1));
         return $updates;
     }
 }

--- a/app/Http/Controllers/EmailController.php
+++ b/app/Http/Controllers/EmailController.php
@@ -10,17 +10,16 @@ class EmailController extends Controller
 {
     public function sendEmail($data, $template)
     {
-        if ( ! isset($data['emailInfo'])) {
-            $data['emailInfo']['template'] = $template;
-            $data['emailInfo']['address'] = 'henry.jiang@sfgov.org';
-            $data['emailInfo']['subject'] = 'Form submissions status';
-            $data['emailInfo']['name'] = 'DS Formbuilder';
-        }
-        try {
-            Mail::to($data['emailInfo']['address'])->send(new FormBuilderMailer($data));
-        }
-        catch(\Swift_TransportException $e){
-            Log::info(print_r($e->getMessage(),1));
+        $data['emailInfo']['template'] = isset($data['emailInfo']['template']) ? $data['emailInfo']['template'] : $template;
+        $data['emailInfo']['address'] = isset($data['emailInfo']['address']) ? $data['emailInfo']['address'] : 'henry.jiang@sfgov.org';
+        $data['emailInfo']['subject'] = isset($data['emailInfo']['subject']) ? $data['emailInfo']['subject'] : 'Form submissions status';
+        $data['emailInfo']['name'] = isset($data['emailInfo']['name']) ? $data['emailInfo']['name'] : 'DS Formbuilder';
+        if ($data['emailInfo']['address'] !== '') {
+            try {
+                Mail::to($data['emailInfo']['address'])->send(new FormBuilderMailer($data));
+            } catch (\Swift_TransportException $e) {
+                Log::info(print_r($e->getMessage(), 1));
+            }
         }
     }
 }

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -71,13 +71,13 @@ class FormController extends Controller
 		$forms = Form::all();
         $user_forms = User_Form::all();
 		$query = User_Form::select('form_id')->where('user_id', $user_id)->get();
-		
+
 		$forms = Form::whereIn('id', $query)->get();
         foreach ($forms as $key => $value) {
 			$forms[$key]['content'] = $this->controllerHelper->scrubString($value['content']);
             $forms[$key]['content'] = json_decode($value['content'], true); //hack to convert json blob to part of larger object
 		}
-		
+
         return response()->json($forms);
     }
 
@@ -412,11 +412,12 @@ class FormController extends Controller
       $form = Form::where('id', $form_id)->first();
       $form['content'] = json_decode($form['content'], true); //hack to convert json blob to part of larger object
       //todo backend validation
-      if($magiclink = $this->dataStoreHelper->submitForm($form, $request, 'partial')){
-          // email magic link to user? confirmation page
+      if($response = $this->dataStoreHelper->submitForm($form, $request, 'partial')){
           $data['body'] = array();
-          $magiclink = urlencode($magiclink);
+          $data['emailInfo'] = array();
+          $magiclink = urlencode($response['magiclink']);
           $data['body']['message'] = 'This is the body of the emails';
+          $data['emailInfo']['address'] = $response['email'];
           $referer = $request->headers->get('referer');
           $host = parse_url($referer, PHP_URL_HOST);
           $path = parse_url($referer, PHP_URL_PATH);

--- a/public/assets/js/embed.js
+++ b/public/assets/js/embed.js
@@ -162,7 +162,7 @@ function initSectional() {
 		jQuery('#SFDSWF-Container .form-section-header').eq(i).addClass('active');
 		jQuery('html,body').animate({ scrollTop: 0 }, 'medium');
 	}
-	
+
 	skipToSectionId(SFDSWF_goto);
 }
 
@@ -203,7 +203,9 @@ function skipToSectionId(callback) { //does not work for checkboxes and possibly
 
 function submitPartial(formid){
   var formid = "SFDSWFB_forms_" + formid;
-  var submitUrl = jQuery("#"+formid).attr('action').replace('submit', 'submitPartial');
+  var submitUrl = jQuery("#"+formid).attr('action');
+  if(!submitUrl.includes('submitPartial'))
+    submitUrl = submitUrl.replace('\/submit', '\/submitPartial');
   jQuery("#"+formid).attr('action', submitUrl);
   document.forms[formid].submit.click();
 }
@@ -211,7 +213,7 @@ function submitPartial(formid){
 SFDSWFB.lastScript = function() {
 
 	skipToSectionId(false)
-	
+
 	jQuery('#SFDSWF-Container input[formtype=c06]').on('keyup blur', function() {
 			if (phoneIsValid(jQuery(this).val())) {
 				fieldValid(jQuery(this).attr('id'));


### PR DESCRIPTION
Currently the form draft email is hard coded, no way for Brian to QA.  Updating the code to extract the email field from the form. Also fix some minor bugs in embed.js where if validation fails in the UI, form action is replaced with incorrect submission endpoint.

- FormController -- use form email address as the default for form draft emails.
- DataStoreHelper -- update function to get email field.
- EmailController -- update default values and only try to send if email address is available.
- embed.js -- fix minor bug.
