### PR TITLE
Backend implementation and templates for resume draft

### DIFF
--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -68,15 +68,16 @@ class FormController extends Controller
     {
         $user_id = $request->input('user_id');
         $user = Auth::user()->where('id', $user_id)->get();
-		$forms = Form::all();
+        $forms = Form::all();
         $user_forms = User_Form::all();
-		$query = User_Form::select('form_id')->where('user_id', $user_id)->get();
+        $query = User_Form::select('form_id')->where('user_id', $user_id)->get();
 
-		$forms = Form::whereIn('id', $query)->get();
+        $forms = Form::whereIn('id', $query)->get();
+
         foreach ($forms as $key => $value) {
-			$forms[$key]['content'] = $this->controllerHelper->scrubString($value['content']);
+            $forms[$key]['content'] = $this->controllerHelper->scrubString($value['content']);
             $forms[$key]['content'] = json_decode($value['content'], true); //hack to convert json blob to part of larger object
-		}
+        }
 
         return response()->json($forms);
     }
@@ -409,26 +410,28 @@ class FormController extends Controller
     */
     public function submitPartialForm(Request $request)
     {
-      $form_id = $request->input('form_id');
-      if (!$form_id) {
-          return "<h1>Oops! Something went wrong.</h1>Please contact SFDS to fix your form.";
-      }
-      $form = Form::where('id', $form_id)->first();
-      $form['content'] = json_decode($form['content'], true); //hack to convert json blob to part of larger object
-      //todo backend validation
-      if($response = $this->dataStoreHelper->submitForm($form, $request, 'partial')){
-          $data['body'] = array();
-          $data['emailInfo'] = array();
-          $magiclink = urlencode($response['magiclink']);
-          $data['body']['message'] = 'This is the body of the emails';
-          $data['emailInfo']['address'] = $response['email'];
-          $referer = $request->headers->get('referer');
-          $host = parse_url($referer, PHP_URL_HOST);
-          $path = parse_url($referer, PHP_URL_PATH);
-          $data['body']['host'] = '//'.$host.$path . "?draft=$magiclink&form_id=$form_id";
-          $this->emailController->sendEmail($data, 'emails.saveForLater');
-          return view('emails.saveForLater', ['data' => $data['body']]);
-		    }
+        $form_id = $request->input('form_id');
+        if (!$form_id) {
+            return "<h1>Oops! Something went wrong.</h1>Please contact SFDS to fix your form.";
+        }
+        $form = Form::where('id', $form_id)->first();
+        $form['content'] = json_decode($form['content'], true); //hack to convert json blob to part of larger object
+        //todo backend validation
+        $referer = $request->headers->get('referer');
+        $host = parse_url($referer, PHP_URL_HOST);
+        $path = parse_url($referer, PHP_URL_PATH);
+        $scheme = parse_url($referer, PHP_URL_SCHEME);
+        $form['host'] = $host !== '' ? $scheme.'://'.$host.$path : '';
+        if ($response = $this->dataStoreHelper->submitForm($form, $request, 'partial')) {
+            $data['body'] = array();
+            $data['emailInfo'] = array();
+            $magiclink = urlencode($response['magiclink']);
+            $data['body']['message'] = 'This is the body of the emails';
+            $data['emailInfo']['address'] = $response['email'];
+            $data['body']['host'] = $form['host'] . "?draft=$magiclink&form_id=$form_id";
+            $this->emailController->sendEmail($data, 'emails.saveForLater');
+            return view('emails.saveForLater', ['data' => $data['body']]);
+        }
     }
 
     /** Determine form has been published
@@ -576,5 +579,44 @@ class FormController extends Controller
 
             sleep(10);
         }
+    }
+
+    /** Get a list of drafts
+    *
+    * @param $request
+    *
+    * @return Page
+    */
+    public function getFormDraftList(Request $request){
+      $hash = $request->input('email');
+      $data = array();
+      if ($hash) {
+          $list = $this->dataStoreHelper->getFormDraftList($hash);
+          if ( (isset($list['status']) && $list['status'] == 0 ) || ! $list) {
+              $template = 'emails.noDraftsFound';
+          } else {
+              $template = 'emails.confirmationDraftList';
+              // send "resume draft" email
+              $data['emailInfo']['address'] = $hash;
+              $data['emailInfo']['subject'] = 'Here is your list of form drafts';
+              $data['body']['list'] = $list;
+              $emailTemplate = 'emails.draftList';
+              $this->emailController->sendEmail($data, $emailTemplate);
+          }
+      }
+      // return "no drafts found" page
+      return view($template, ['data' => $data]);
+    }
+
+    /** Let user check form drafts based on input email
+    *
+    * @param $request
+    *
+    * @return Page
+    */
+    public function resumeDraft(Request $request){
+        $template = 'emails.resumeDraft';
+        $url = '//'.$request->getHttpHost(). '/form/draft-list';
+        return view($template, ['host' => $url]);
     }
 }

--- a/database/migrations/2019_11_12_201006_create_table_from_drafts.php
+++ b/database/migrations/2019_11_12_201006_create_table_from_drafts.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTableFromDrafts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('form_table_drafts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+            $table->string('email');
+            $table->string('host');
+            $table->string('magiclink');
+            $table->integer('form_table_id');
+            $table->integer('form_record_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //Schema::dropIfExists('table_from_drafts');
+    }
+}

--- a/docker/mysql-data/webform-dump.sql
+++ b/docker/mysql-data/webform-dump.sql
@@ -134,10 +134,25 @@ DROP TABLE IF EXISTS `enum_mappings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `enum_mappings` (
-  `id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `form_table_id` smallint(6) DEFAULT NULL,
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `form_table_id` int(10) unsigned DEFAULT NULL,
   `form_field_name` varchar(255) DEFAULT NULL,
   `value` varchar(255) DEFAULT NULL,
+  `type` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+
+) ENGINE=InnoDB AUTO_INCREMENT=3632 DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `form_table_drafts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `form_table_drafts` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `form_table_id` int(10) unsigned DEFAULT NULL,
+  `form_record_id` int(10) unsigned DEFAULT NULL,
+  `email` varchar(255) DEFAULT NULL,
+  `host` varchar(255) DEFAULT NULL,
+  `magiclink` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
 
 ) ENGINE=InnoDB AUTO_INCREMENT=3632 DEFAULT CHARSET=utf8;

--- a/resources/views/emails/confirmationDraftList.blade.php
+++ b/resources/views/emails/confirmationDraftList.blade.php
@@ -1,0 +1,3 @@
+<div>
+  <h2> Please check your email for a list of form drafts</h2>
+</div>

--- a/resources/views/emails/draftList.blade.php
+++ b/resources/views/emails/draftList.blade.php
@@ -1,0 +1,8 @@
+<div>
+  <h2> Here is a list of your form drafts</h2>
+  <ul>
+    @foreach ($data['list'] as $list)
+      <li> <a href="{{ $list['host'] }}?draft={{ $list['magiclink'] }}&form_id={{ $list['form_id'] }}"> {{ $list['host'] }}?draft={{ $list['magiclink'] }}&form_id={{ $list['form_id'] }}</a></li>
+    @endforeach
+  </ul>
+</div>

--- a/resources/views/emails/noDraftsFound.blade.php
+++ b/resources/views/emails/noDraftsFound.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <h2>No form drafts found</h2>
+</div>

--- a/resources/views/emails/resumeDraft.blade.php
+++ b/resources/views/emails/resumeDraft.blade.php
@@ -1,0 +1,11 @@
+<form action="{{ $host }}" method='POST'>
+<fieldset>
+<div>
+    <h2>Retrieve your form drafts</h2>
+</div>
+<div>
+    <input type='text' name='email'/>
+</div>
+<div> <input type='submit' name='submit' value='Submit'></div>
+</fieldset>
+</form>

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,6 +46,8 @@ $router->group(['prefix' => 'form'], function($router) {
 	  $router->post('csv-published', ['as' => 'csv-published', 'uses' => 'FormController@CSVPublished']);
     $router->post('purge-csv', ['as' => 'purge-csv', 'uses' => 'FormController@purgeCSV']);
     $router->post('export-csv', ['as' => 'export-csv', 'uses' => 'FormController@exportFormData']);
+    $router->get('resume-draft', ['as' => 'resume-draft', 'uses' => 'FormController@resumeDraft']);
+    $router->post('draft-list', ['as' => 'draft-list', 'uses' => 'FormController@getFormDraftList']);
 });
 
 $router->group(['prefix' => 'api'], function($router) {


### PR DESCRIPTION
This PR creates the baseline for resume draft feature. It probably could benefit from more user story organization, but user story and tasks will touch the same set of files. Therefore the files are bundled as-is to avoid merge conflicts. 

-  app/Helpers/DataStoreHelper.php -- main implementation.  Reworked several functions based on database structure updates and new feature.
- 	app/Http/Controllers/FormController.php -- Controller function for routes
- 	routes/api.php -- add routes to resume draft
- 	database/migrations/2019_11_12_201006_create_table_from_drafts.php -- database structure mods
- 	docker/mysql-data/webform-dump.sql -- database structure mods
        // The following files are template placeholders for Josh R. to design and edit
- 	resources/views/emails/confirmationDraftList.blade.php
- 	resources/views/emails/draftList.blade.php
- 	resources/views/emails/noDraftsFound.blade.php
- 	resources/views/emails/resumeDraft.blade.php

