### PR TITLE
Update Heroku config for Review App

### DIFF
--- a/app.json
+++ b/app.json
@@ -50,6 +50,30 @@
     "FILE_SALT": {
       "required": true
     },
+    "MAIL_DRIVER": {
+      "required": true
+    },
+    "MAIL_ENCRYPTION": {
+      "required": true
+    },
+    "MAIL_FROM_ADDRESS": {
+      "required": true
+    },
+    "MAIL_FROM_NAME": {
+      "required": true
+    },
+    "MAIL_HOST": {
+      "required": true
+    },
+    "MAIL_PASSWORD": {
+      "required": true
+    },
+    "MAIL_PORT": {
+      "required": true
+    },
+    "MAIL_USERNAME": {
+      "required": true
+    },
     "SENTRY_DSN": {
       "required": true
     }


### PR DESCRIPTION
Heroku Review App doesn't automatically pull in all environment variables from Staging. This is in contrary to [Heroku's documentation](https://devcenter.heroku.com/articles/github-integration-review-apps). 

Update app.json to include all env vars from Staging.