### PR TITLE
Styling fixes for PL integration

### DIFF
--- a/public/assets/css/form-base.css
+++ b/public/assets/css/form-base.css
@@ -33,7 +33,7 @@ input[type="radio"] + label {
 input[type="checkbox"],
 input[type="radio"] {
 	margin-right: 1rem;
-  width: auto;
+	width: auto;
 }
 
 .help-text {


### PR DESCRIPTION
This PR fixes two bugs noticed while testing SG-854.

1.`length-1`, `length-2`, etc. classes aren't applied because of overly specific selectors in `form-base`
2. Empty help text blocks add unwanted bottom margins to each field